### PR TITLE
Yang configure input trace back  fix when input is dict

### DIFF
--- a/changelogs/fragments/31_configure_file_required_true.yaml
+++ b/changelogs/fragments/31_configure_file_required_true.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - file attribute set as mandatory to validate the input json config.

--- a/changelogs/fragments/33_configure_input_fix.yaml
+++ b/changelogs/fragments/33_configure_input_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - This checks for the loaded json config and converts to json string if input is dict.

--- a/plugins/action/configure.py
+++ b/plugins/action/configure.py
@@ -118,6 +118,9 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
 
         json_config = json.loads(self._task.args.get("config") or {})
+        if isinstance(json_config, dict):
+            json_config = json.dumps(json_config)
+
         yang_file = self._task.args.get("file") or None
         search_path = self._task.args.get("search_path") or None
         if not (

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -36,6 +36,8 @@ options:
       - The file path of the YANG model that corresponds to the configuration fetch from the remote host.
         This options accepts wildcard (*) as well for the filename in case the configuration requires
         to parse multiple yang file. For example "openconfig/public/tree/master/release/models/interfaces/*.yang"
+    required: True
+    type: path
   search_path:
     description:
       - is a colon C(:) separated list of directories to search for imported yang modules


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
resolve: 
- https://github.com/ansible-collections/community.yang/issues/27

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yang_configure
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Input could be provided in  following: 
```
community.yang.configure:
        config: "{{ lookup('file', config_file) | to_json }}"
        file: "{{ yang_file }}"
```
```
- name: Configure interface description
      community.yang.configure:
        config: |
          {
              "Cisco-IOS-XR-ifmgr-cfg:interface-configurations": {
                  "interface-configuration": [
                      {
                          "active": "act",
                          "description": "test for ansible 200",
                          "interface-name": "Loopback888",
                          "interface-virtual": [
                              null
                          ],
                          "shutdown": [
                              null
                          ]
                      },
              }
          }
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
