### PR TITLE
Yang configure input trace back fix when input is dict 

### DIFF
--- a/changelogs/fragments/34_configure_input_fix.yaml
+++ b/changelogs/fragments/34_configure_input_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - input config type is dict now and json config can provided when translator object invoked.

--- a/plugins/action/configure.py
+++ b/plugins/action/configure.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
         that cannot be covered using stnd techniques
         """
         errors = []
-        config = self._task.args.get("config") or None
+        config = json.dumps(self._task.args.get("config"))
         try:
             # validate json
             json.loads(config)
@@ -117,7 +117,8 @@ class ActionModule(ActionBase):
             return self._result
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        json_config = json.loads(self._task.args.get("config") or {})
+        json_config = self._task.args.get("config")
+
         yang_file = self._task.args.get("file") or None
         search_path = self._task.args.get("search_path") or None
         if not (

--- a/plugins/module_utils/translator.py
+++ b/plugins/module_utils/translator.py
@@ -29,7 +29,6 @@ from ansible_collections.community.yang.plugins.module_utils.common import (
     find_file_in_path,
     find_share_path,
 )
-from ansible.errors import AnsibleActionFail
 
 display = Display()
 
@@ -67,7 +66,6 @@ class Translator(object):
 
     def _handle_yang_file_path(self, yang_file):
         yang_file = os.path.realpath(os.path.expanduser(yang_file))
-
         if not os.path.isfile(yang_file):
             # Maybe we are passing a glob?
             self._yang_files = glob.glob(yang_file)
@@ -110,7 +108,6 @@ class Translator(object):
         :param json_data: JSON data that should to translated to XML
         :return: XML data in string format.
         """
-
         saved_arg = deepcopy(sys.argv)
         saved_stdout = sys.stdout
         saved_stderr = sys.stderr

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -22,7 +22,7 @@ options:
   config:
     description:
       - The running-configuration to be pushed onto the device in JSON format (as per RFC 7951).
-    type: str
+    type: dict
     required: True
   get_filter:
     description:
@@ -59,7 +59,7 @@ diff:
 EXAMPLES = """
 - name: configure interface using structured data in JSON format
   community.yang.configure:
-    config: |
+    config:
         {
             "openconfig-interfaces:interfaces":
              {
@@ -88,4 +88,10 @@ EXAMPLES = """
         </interface-configuration></interface-configurations>
     file: "{{ playbook_dir }}/public/release/models/interfaces/openconfig-interfaces.yang"
     search_path: "{{ playbook_dir }}/public/release/models"
+
+- name: Configure native data to running-config
+  community.yang.configure:
+    config: "{{ candidate['json_data'] }}"
+    file: "{{ yang_file }}"
+    search_path: "{{ search_path }}"
 """


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
resolve: 
- https://github.com/ansible-collections/community.yang/issues/27
- https://github.com/ansible-collections/community.yang/issues/26
- https://github.com/ansible-collections/community.yang/issues/24
config type changes to dict
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yang_configure
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
```
community.yang.configure:
        config: "{{ lookup('file', config_file) }}"
        file: "{{ yang_file }}"
```
```
- name: Configure interface description
      community.yang.configure:
        config: 
          {
              "Cisco-IOS-XR-ifmgr-cfg:interface-configurations": {
                  "interface-configuration": [
                      {
                          "active": "act",
                          "description": "test for ansible 200",
                          "interface-name": "Loopback888",
                          "interface-virtual": [
                              null
                          ],
                          "shutdown": [
                              null
                          ]
                      },
              }
          }
```
```
- name: Configure native data to running-config
  community.yang.configure:
    config: "{{ candidate['json_data'] }}"
    file: "{{ yang_file }}"
    search_path: "{{ search_path }}"
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
