### PR TITLE
Fix file check logic for xml and json data

### DIFF
--- a/plugins/module_utils/translator.py
+++ b/plugins/module_utils/translator.py
@@ -118,12 +118,16 @@ class Translator(object):
             )
             with open(json_file_path, "w") as f:
                 f.write(json.dumps(json_data))
-            json_file_path = os.path.realpath(os.path.expanduser(json_file_path))
+            json_file_path = os.path.realpath(
+                os.path.expanduser(json_file_path)
+            )
 
         elif os.path.isfile(json_data):
             json_file_path = json_data
         else:
-            raise AnsibleError("unable to create/find temporary json file %s" % json_data)
+            raise AnsibleError(
+                "unable to create/find temporary json file %s" % json_data
+            )
 
         try:
             # validate json
@@ -275,10 +279,14 @@ class Translator(object):
             else:
                 if not self._keep_tmp_files:
                     shutil.rmtree(
-                        os.path.realpath(os.path.expanduser(XM2JSONL_DIR_PATH)),
+                        os.path.realpath(
+                            os.path.expanduser(XM2JSONL_DIR_PATH)
+                        ),
                         ignore_errors=True,
                     )
-                raise AnsibleError("Unable to create file or read XML data %s" % xml_data)
+                raise AnsibleError(
+                    "Unable to create file or read XML data %s" % xml_data
+                )
 
         xml_file_path = os.path.realpath(os.path.expanduser(xml_file_path))
 
@@ -292,7 +300,9 @@ class Translator(object):
             except Exception as exc:
                 if not self._keep_tmp_files:
                     shutil.rmtree(
-                        os.path.realpath(os.path.expanduser(XM2JSONL_DIR_PATH)),
+                        os.path.realpath(
+                            os.path.expanduser(XM2JSONL_DIR_PATH)
+                        ),
                         ignore_errors=True,
                     )
                 raise AnsibleError(

--- a/plugins/module_utils/translator.py
+++ b/plugins/module_utils/translator.py
@@ -117,7 +117,7 @@ class Translator(object):
                 os.path.expanduser(json_file_path)
             )
             with open(json_file_path, "w") as f:
-                f.write(json_data)
+                f.write(json.dumps(json_data))
             json_file_path = os.path.realpath(os.path.expanduser(json_file_path))
 
         elif os.path.isfile(json_data):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.yang/issues/27

*  Instead of isfile check add logic to check
   of type check in cse of json and xml validity
   in case of xml data
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
