### PR TITLE
Fix community.yang.fetch module issues

### DIFF
--- a/changelogs/fragments/18-requirement_list_fix.yaml
+++ b/changelogs/fragments/18-requirement_list_fix.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fixed jxmlease is required for fetch, but not listed in docs.
+    Use xmltodict instead of jxmlease
+    (https://github.com/ansible-collections/community.yang/issues/18)

--- a/changelogs/fragments/19-connection_type_chec.yaml
+++ b/changelogs/fragments/19-connection_type_chec.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed traceback in fetch when the ansible_connection is set to ansible.netcommon.network_cli
+    (https://github.com/ansible-collections/community.yang/issues/18)

--- a/changelogs/fragments/20-fix_yang_schema_monitoring_capability.yaml
+++ b/changelogs/fragments/20-fix_yang_schema_monitoring_capability.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed traceback when using fetch with nxos
+    (https://github.com/ansible-collections/community.yang/issues/20)

--- a/changelogs/fragments/21-sort_supported_yang_module_list.yaml
+++ b/changelogs/fragments/21-sort_supported_yang_module_list.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added support to sort supported yang models returned with fetch
+    (https://github.com/ansible-collections/community.yang/issues/21).

--- a/plugins/action/configure.py
+++ b/plugins/action/configure.py
@@ -34,6 +34,8 @@ from ansible_collections.community.yang.plugins.module_utils.translator import (
     Translator,
 )
 
+VALID_CONNECTION_TYPES = ["ansible.netcommon.netconf"]
+
 
 def generate_argspec():
     """ Generate an argspec
@@ -111,6 +113,15 @@ class ActionModule(ActionBase):
         :param kwargs:
         :return:
         """
+        if self._play_context.connection.split(".")[-1] != "netconf":
+            return {
+                "failed": True,
+                "msg": "Connection type %s is not valid for this module. Valid connection type is one of '%s'."
+                % (
+                    self._play_context.connection,
+                    ", ".join(VALID_CONNECTION_TYPES),
+                ),
+            }
         self._check_argspec()
         self._extended_check_argspec()
         if self._result.get("failed"):

--- a/plugins/action/generate_spec.py
+++ b/plugins/action/generate_spec.py
@@ -30,6 +30,7 @@ ARGSPEC_CONDITIONALS = {
     "required_one_of": [["file", "content"]],
     "mutually_exclusive": [["file", "content"]],
 }
+VALID_CONNECTION_TYPES = ["ansible.netcommon.netconf"]
 
 
 def generate_argspec():
@@ -94,6 +95,15 @@ class ActionModule(ActionBase):
         :param kwargs:
         :return:
         """
+        if self._play_context.connection.split(".")[-1] != "netconf":
+            return {
+                "failed": True,
+                "msg": "Connection type %s is not valid for this module. Valid connection type is one of '%s'."
+                % (
+                    self._play_context.connection,
+                    ", ".join(VALID_CONNECTION_TYPES),
+                ),
+            }
         self._check_argspec()
         self._extended_check_argspec()
         if self._result.get("failed"):

--- a/plugins/action/get.py
+++ b/plugins/action/get.py
@@ -30,6 +30,8 @@ from ansible_collections.community.yang.plugins.modules.get import (
     DOCUMENTATION,
 )
 
+VALID_CONNECTION_TYPES = ["ansible.netcommon.netconf"]
+
 
 class ActionModule(ActionBase):
     def __init__(self, *args, **kwargs):
@@ -83,6 +85,16 @@ class ActionModule(ActionBase):
             self._result["msg"] = " ".join(errors)
 
     def run(self, tmp=None, task_vars=None):
+        if self._play_context.connection.split(".")[-1] != "netconf":
+            return {
+                "failed": True,
+                "msg": "Connection type %s is not valid for this module. Valid connection type is one of '%s'."
+                % (
+                    self._play_context.connection,
+                    ", ".join(VALID_CONNECTION_TYPES),
+                ),
+            }
+
         self._check_argspec()
         self._extended_check_argspec()
         if self._result.get("failed"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ansible
 ncclient
 pyang
-jxmlease
+xmltodict

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ mock ; python_version < '3.5'
 pytest-xdist
 yamllint
 lxml
+xmltodict


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.yang/issues/21
Fixes https://github.com/ansible-collections/community.yang/issues/18
Fixes https://github.com/ansible-collections/community.yang/issues/19
Fixes  https://github.com/ansible-collections/community.yang/issues/20

*  Sort the supported list of yang modules before returining in response
*  Add ``jxmlease`` library requirement in doc as it is used by
   netconf_get module which is invoked by ``community.yang.get`` module
*  Add connection type validitiy check. Currently the plugins support
   only community.yang.netconf connection type
*  Check if remote netconf server supports fetching yang model by
   checking for ``urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring``
   capability in server capabilities.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fetch
get
configure
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
