### PR TITLE
sort yang_files to address dependency issue

### DIFF
--- a/plugins/module_utils/translator.py
+++ b/plugins/module_utils/translator.py
@@ -79,6 +79,11 @@ class Translator(object):
                 self._yang_files.extend(_yang_files)
             else:
                 self._yang_files.append(yang_file)
+
+        # glob.glob returns the files unordered when doing wildcard
+        # sort to fix some dependency issues
+        self._yang_files.sort()
+
         # ensure file path entry is unique
         self._yang_files = list(set(self._yang_files))
 


### PR DESCRIPTION
##### SUMMARY
The glob.glob returns files in unsorted order when doing wildcard, when yang files required to be processed in order, this could break the dependency. Added sort to address this issue.



##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
plugins/module_utils/translator.py

##### ADDITIONAL INFORMATION
This change should have no impacts to yang files without internal dependency
