### PR TITLE
adding the continue_on_failure attribute

### DIFF
--- a/changelogs/fragments/40_continue_on_failure.yaml
+++ b/changelogs/fragments/40_continue_on_failure.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - added optional attribute for fetch action to continue if it hits a module that cannot be found

--- a/plugins/action/fetch.py
+++ b/plugins/action/fetch.py
@@ -105,17 +105,21 @@ class ActionModule(ActionBase):
 
         result["fetched"] = dict()
         if continue_on_failure:
-           result['failed_yang_models'] = []
+            result["failed_yang_models"] = []
         total_count = 0
         try:
             supported_yang_modules = ss.get_schema_description()
             if schema:
                 if schema == "all":
                     for item in supported_yang_modules:
-                        changed, counter = ss.run(item, result, continue_on_failure)
+                        changed, counter = ss.run(
+                            item, result, continue_on_failure
+                        )
                         total_count += counter
                 else:
-                    changed, total_count = ss.run(schema, result, continue_on_failure)
+                    changed, total_count = ss.run(
+                        schema, result, continue_on_failure
+                    )
         except ValueError as exc:
             return {"failed": True, "msg": to_text(exc)}
 

--- a/plugins/action/fetch.py
+++ b/plugins/action/fetch.py
@@ -89,6 +89,7 @@ class ActionModule(ActionBase):
 
         schema = self._task.args.get("name")
         dir_path = self._task.args.get("dir")
+        continue_on_failure = self._task.args.get("continue_on_failure", False)
         socket_path = self._connection.socket_path
         conn = Connection(socket_path)
 
@@ -103,16 +104,18 @@ class ActionModule(ActionBase):
         ss = SchemaStore(conn)
 
         result["fetched"] = dict()
+        if continue_on_failure:
+           result['failed_yang_models'] = []
         total_count = 0
         try:
             supported_yang_modules = ss.get_schema_description()
             if schema:
                 if schema == "all":
                     for item in supported_yang_modules:
-                        changed, counter = ss.run(item, result)
+                        changed, counter = ss.run(item, result, continue_on_failure)
                         total_count += counter
                 else:
-                    changed, total_count = ss.run(schema, result)
+                    changed, total_count = ss.run(schema, result, continue_on_failure)
         except ValueError as exc:
             return {"failed": True, "msg": to_text(exc)}
 

--- a/plugins/module_utils/fetch.py
+++ b/plugins/module_utils/fetch.py
@@ -107,14 +107,18 @@ class SchemaStore(object):
             if not continue_on_error:
                 raise ValueError("Fail to fetch '%s' yang model" % schema_id)
             else:
-               display.vvv("Fail to fetch '%s' yang model" % schema_id)
-               result['failed_yang_models'].append(schema_id)
+                display.vvv("Fail to fetch '%s' yang model" % schema_id)
+                result["failed_yang_models"].append(schema_id)
 
         return found, data_model
 
-    def get_schema_and_dependants(self, schema_id, result, continue_on_failure=False):
+    def get_schema_and_dependants(
+        self, schema_id, result, continue_on_failure=False
+    ):
         try:
-            found, data_model = self.get_one_schema(schema_id, result, continue_on_failure)
+            found, data_model = self.get_one_schema(
+                schema_id, result, continue_on_failure
+            )
         except ValueError as exc:
             raise ValueError(exc)
 
@@ -140,7 +144,9 @@ class SchemaStore(object):
                 counter -= 1
                 continue
 
-            schema_dlist = self.get_schema_and_dependants(schema_id, result, continue_on_failure)
+            schema_dlist = self.get_schema_and_dependants(
+                schema_id, result, continue_on_failure
+            )
             for schema_id in schema_dlist:
                 if schema_id not in result["fetched"]:
                     sq.put(schema_id)

--- a/plugins/modules/fetch.py
+++ b/plugins/modules/fetch.py
@@ -30,8 +30,8 @@ options:
         name prefixed with `.yang` extension.
   continue_on_failure:
     description:
-      - This is an optional arguement that allows schema fetch to continue if  one the 
-        desired schemas fails download
+      - This is an optional arguement that allows schema fetch to continue if one the
+        desired models fails download
 requirements:
 - ncclient (>=v0.5.2)
 - pyang

--- a/plugins/modules/fetch.py
+++ b/plugins/modules/fetch.py
@@ -32,6 +32,8 @@ options:
     description:
       - This is an optional arguement that allows schema fetch to continue if one the
         desired models fails download
+    type: bool
+    default: false
 requirements:
 - ncclient (>=v0.5.2)
 - pyang

--- a/plugins/modules/fetch.py
+++ b/plugins/modules/fetch.py
@@ -28,6 +28,10 @@ options:
       - This is an optional argument which provide the directory path in which the fetched
         yang modules will be saved. The name of the file is same as that of the yang module
         name prefixed with `.yang` extension.
+  continue_on_failure:
+    description:
+      - This is an optional arguement that allows schema fetch to continue if  one the 
+        desired schemas fails download
 requirements:
 - ncclient (>=v0.5.2)
 - pyang
@@ -55,6 +59,11 @@ supported_yang_modules:
   returned: only when model name is not provided
   type: list
   sample: ["ietf-netconf-monitoring", "cisco-xr-ietf-netconf-monitoring-deviations"]
+failed_yang_modules:
+  decription: List of yang models that failed download
+  returned: only when continue_on_failure is true
+  type: list
+  sample: ["ietf-netconf-monitoring", "cisco-xr-ietf-netconf-monitoring-deviations"]
 """
 EXAMPLES = """
 - name: Fetch given yang model from remote host
@@ -71,4 +80,10 @@ EXAMPLES = """
   community.yang.fetch:
     name: all
     dir: "{{ playbook_dir }}/yang_files"
+
+- name: Fetch all the yang models supported by remote host and store it in dir location do not stop on error
+  community.yang.fetch:
+    name: all
+    dir: "{{ playbook_dir }}/yang_files"
+    continue_on_failure: true
 """


### PR DESCRIPTION
##### SUMMARY
Adding the ability for the fetch action to continue even if a model is not fetched.  There a couple of cases in ArcOS where this is helpful.

1) There are a few yang models in ArcOS that have the word 'import' in a leaf description.  This causes this module to try to import this module, which doesn't exist e.g. in the `tail-f-common.yang` model there is this text:

```

1723        The argument to 'tailf:unique-selector' is an XPath descendant
1724        location path (matches the rule 'descendant-schema-nodeid' in
1725        RFC 6020).  The first node in the path MUST be a list node, and
1726        it MUST be defined in the same module as the
1727        tailf:unique-selector.  For example, the following is illegal:
1728
1729          module y {
1730            ...
1731            import x {
1732              prefix x;
1733            }
1734            tailf:unique-selector '/x:server' { // illegal
1735              ...
1736            }
1737          }
```
this causes this collection to try to fetch model `x`

The other use case is sometimes ArcOS will list a model in the get-schema RPC call but the full model might not exist on a specific version or a specific HW model  Therefore if the `all` keyword is used in this collection and a model doesn't not exist on the device this task will fail.


##### ISSUE TYPE
 Feature Pull Request

##### COMPONENT NAME
community.yang.fetch

##### ADDITIONAL INFORMATION
Here is an example run with the tasks failing:
```
  1 ---
  2 - hosts: all
  3   gather_facts: false
  4   connection: ansible.netcommon.netconf
  5
  6   tasks:
  7    - name: Fetch given yang model and it’s dependent models from remote host
  8      community.yang.fetch:
  9        name: all
```
```
TASK [Fetch given yang model and it’s dependent models from remote host] *********************************************************************************************
task path: /Users/david/code/ansible_netconf/netconf_test.yml:7
Fetched 'INET-ADDRESS-MIB' yang model
Fetched 'ietf-yang-smiv2' yang model
Fetched 'IPV6-TC' yang model
Fetched 'ietf-inet-types' yang model
Fetched 'tailf-common' yang model
fatal: [10.27.103.37]: FAILED! => {
    "changed": false,
    "msg": "Fail to fetch 'x' yang model"
}

PLAY RECAP **********************************
```

With my change the following attribute is added: `continue_on_failure`
```

  1 ---
  2 - hosts: all
  3   gather_facts: false
  4   connection: ansible.netcommon.netconf
  5
  6   tasks:
  7    - name: Fetch given yang model and it’s dependent models from remote host
  8      community.yang.fetch:
  9        name: all
 10        continue_on_failure: true
```
With this being run we are able to continue past the failed models and return a list of failed models
```

TASK [Fetch given yang model and it’s dependent models from remote host] *********************************************************
task path: /Users/david/code/ansible_netconf/netconf_test.yml:7
Fetched 'INET-ADDRESS-MIB' yang model
Fetched 'ietf-yang-smiv2' yang model
Fetched 'IPV6-TC' yang model
Fetched 'ietf-inet-types' yang model
Fetched 'tailf-common' yang model
Fail to fetch 'x' yang model
Fetched 'SNMPv2-SMI' yang model
Fetched 'ietf-yang-types' yang model
Fetched 'SNMPv2-TC' yang model
Fetched 'TRANSPORT-ADDRESS-MIB' yang model
<snip>
changed: [10.27.103.37] => {
    "changed": true,
    "failed_yang_models": [
        "x",
        "openconfig-mpls",
        "openconfig-ospfv2",
        "openconfig-policy-forwarding",
        "openconfig-authentication-types",
<snip>
```
This attribute defaults to False so the current behavior is unchanged and the user must opt in to allow for the continuation to happen.
