### PR TITLE
Add netconf_options to allow passing args to netconf_config

### DIFF
--- a/changelogs/fragments/58-add_netconf_options.yml
+++ b/changelogs/fragments/58-add_netconf_options.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - community.yang.configure - Since ``configure`` module is built on top of ``netconf_config`` we add a new option argument, ``netconf_options``, allowing passing options directly to ``netconf_config``.

--- a/plugins/action/configure.py
+++ b/plugins/action/configure.py
@@ -77,6 +77,7 @@ class ActionModule(ActionBase):
         and instantiate an AnsibleModule to validate
         """
         argspec = generate_argspec()
+
         basic._ANSIBLE_ARGS = to_bytes(
             json.dumps({"ANSIBLE_MODULE_ARGS": self._task.args})
         )
@@ -172,8 +173,13 @@ class ActionModule(ActionBase):
             )
         else:
             new_module_args = self._task.args.copy()
+            if "netconf_options" in self._task.args:
+                new_module_args.update(
+                    self._task.args["netconf_options"].copy()
+                )
             new_module_args["content"] = xml_data
-            for item in ["file", "search_path", "config"]:
+
+            for item in ["file", "search_path", "config", "netconf_options"]:
                 new_module_args.pop(item, None)
 
             self._display.vvvv(

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -46,6 +46,151 @@ options:
         the default directory path.
     type: path
     default: "~/.ansible/yang/spec"
+  netconf_options:
+    description:
+    - Pass arguments to the lower level component, M(ansible.netcommon.netconf_config), that this module uses.
+    type: dict
+    suboptions:
+      target:
+        description: Name of the configuration datastore to be edited. - auto, uses candidate
+          and fallback to running - candidate, edit <candidate/> datastore and then commit
+          - running, edit <running/> datastore directly
+        default: auto
+        type: str
+        choices:
+        - auto
+        - candidate
+        - running
+        aliases:
+        - datastore
+      source_datastore:
+        description:
+        - Name of the configuration datastore to use as the source to copy the configuration
+          to the datastore mentioned by C(target) option. The values can be either I(running),
+          I(candidate), I(startup) or a remote URL
+        type: str
+        aliases:
+        - source
+      lock:
+        description:
+        - Instructs the module to explicitly lock the datastore specified as C(target).
+          By setting the option value I(always) is will explicitly lock the datastore
+          mentioned in C(target) option. It the value is I(never) it will not lock the
+          C(target) datastore. The value I(if-supported) lock the C(target) datastore
+          only if it is supported by the remote Netconf server.
+        type: str
+        default: always
+        choices:
+        - never
+        - always
+        - if-supported
+      default_operation:
+        description:
+        - The default operation for <edit-config> rpc, valid values are I(merge), I(replace)
+          and I(none). If the default value is merge, the configuration data in the C(content)
+          option is merged at the corresponding level in the C(target) datastore. If the
+          value is replace the data in the C(content) option completely replaces the configuration
+          in the C(target) datastore. If the value is none the C(target) datastore is
+          unaffected by the configuration in the config option, unless and until the incoming
+          configuration data uses the C(operation) operation to request a different operation.
+        type: str
+        choices:
+        - merge
+        - replace
+        - none
+      confirm:
+        description:
+        - This argument will configure a timeout value for the commit to be confirmed
+          before it is automatically rolled back. If the C(confirm_commit) argument is
+          set to False, this argument is silently ignored. If the value of this argument
+          is set to 0, the commit is confirmed immediately. The remote host MUST support
+          :candidate and :confirmed-commit capability for this option to .
+        type: int
+        default: 0
+      confirm_commit:
+        description:
+        - This argument will execute commit operation on remote device. It can be used
+          to confirm a previous commit.
+        type: bool
+        default: no
+      error_option:
+        description:
+        - This option controls the netconf server action after an error occurs while editing
+          the configuration.
+        - If I(error_option=stop-on-error), abort the config edit on first error.
+        - If I(error_option=continue-on-error), continue to process configuration data
+          on error. The error is recorded and negative response is generated if any errors
+          occur.
+        - If I(error_option=rollback-on-error), rollback to the original configuration
+          if any error occurs. This requires the remote Netconf server to support the
+          I(error_option=rollback-on-error) capability.
+        default: stop-on-error
+        type: str
+        choices:
+        - stop-on-error
+        - continue-on-error
+        - rollback-on-error
+      save:
+        description:
+        - The C(save) argument instructs the module to save the configuration in C(target)
+          datastore to the startup-config if changed and if :startup capability is supported
+          by Netconf server.
+        default: false
+        type: bool
+      backup:
+        description:
+        - This argument will cause the module to create a full backup of the current C(running-config)
+          from the remote device before any changes are made. If the C(backup_options)
+          value is not given, the backup file is written to the C(backup) folder in the
+          playbook root directory or role root directory, if playbook is part of an ansible
+          role. If the directory does not exist, it is created.
+        type: bool
+        default: no
+      delete:
+        description:
+        - It instructs the module to delete the configuration from value mentioned in
+          C(target) datastore.
+        type: bool
+        default: no
+      commit:
+        description:
+        - This boolean flag controls if the configuration changes should be committed
+          or not after editing the candidate datastore. This option is supported only
+          if remote Netconf server supports :candidate capability. If the value is set
+          to I(False) commit won't be issued after edit-config operation and user needs
+          to handle commit or discard-changes explicitly.
+        type: bool
+        default: true
+      validate:
+        description:
+        - This boolean flag if set validates the content of datastore given in C(target)
+          option. For this option to work remote Netconf server should support :validate
+          capability.
+        type: bool
+        default: false
+      backup_options:
+        description:
+        - This is a dict object containing configurable options related to backup file
+          path. The value of this option is read only when C(backup) is set to I(yes),
+          if C(backup) is set to I(no) this option will be silently ignored.
+        suboptions:
+          filename:
+            description:
+            - The filename to be used to store the backup configuration. If the filename
+              is not given it will be generated based on the hostname, current time and
+              date in format defined by <hostname>_config.<current-date>@<current-time>
+            type: str
+          dir_path:
+            description:
+            - This option provides the path ending with directory name in which the backup
+              configuration file will be stored. If the directory does not exist it will
+              be first created and the filename is either the value of C(filename) or
+              default filename as described in C(filename) options description. If the
+              path value is not given in that case a I(backup) directory will be created
+              in the current working directory and backup configuration will be copied
+              in C(filename) within I(backup) directory.
+            type: path
+        type: dict
 requirements:
 - ncclient (>=v0.5.2)
 - pyang
@@ -102,4 +247,14 @@ EXAMPLES = """
     config: "{{ candidate['json_data'] }}"
     file: "{{ yang_file }}"
     search_path: "{{ search_path }}"
+
+- name: Netconf options
+  community.yang.configure:
+    config: "{{ lookup('file', 'interfaces-config.json') }}"
+    file: "{{ playbook_dir }}/public/release/models/interfaces/openconfig-interfaces.yang"
+    search_path: "{{ playbook_dir }}/public/release/models"
+    netconf_options:
+      lock: never
+      username: system
+      password: complex_password
 """


### PR DESCRIPTION
##### SUMMARY
Netconf `ansible.netcommon.netconf_config` has many options that makes it flexible. So, although `community.yang.configure` provides good functionality on top of `netconf`, it can't be used at full strength as we may need features of `netconf_config` that are not accessible.

Given that `community.yang.configure` is built on top of `ansible.netcommon.netconf_config`, we can easily pass argument options directly to it. Therefore, this PR adds a new option, `netconf_options`, to allow users to pass options directly to` neconf_config`.

The DOCUMENTION for the suboptions of `neconf_options` are taken from `netconf_config` with the following exceptions:
- `content, source_datastore, delete, confirm_commit` are removed; `content` is always set by `community.yang.configure` and  they are mutually exclusive.
- `format` is removed: this is the format of data passed as input in content field an supported by the device, yang module prepares the data for the content option in a single format so no need to support this option
- `get_filter` is removed: already set by get_filter of `community.yang.configure`.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
community.yang.configure

##### ADDITIONAL INFORMATION
Usage:
```yaml
- name: pass arguments to netconf_config
  community.yang.configure:
    config: "{{ lookup('file', 'interfaces-config.json') }}"
    file: "{{ playbook_dir }}/public/release/models/interfaces/openconfig-interfaces.yang"
    search_path: "{{ playbook_dir }}/public/release/models"
    netconf_options:
      lock: never
      username: system
      password: complex_password
```

Error when setting a netconf_config invalid option:
```
TASK [Execute yang netconf_config] **************************************************************************************************************
task path: /home/dn/workspace/ansible/yang-features/demo_04_yang_configure.yml:6
fatal: [dn-hw-ncc]: FAILED! => {
    "changed": false,
    "msg": "Unsupported parameters for (basic.pyc) module: aaaa found in netconf_options. Supported parameters include: backup, backup_options, commit, confirm, confirm_commit, default_operation, delete, error_option, lock, save, source_datastore, target, validate"
}
```
