### PR TITLE
Fix find dependant imports

### DIFF
--- a/changelogs/fragments/fix_find_dependant_imports.yml
+++ b/changelogs/fragments/fix_find_dependant_imports.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - remove description block from yang before matching imports to prevent false positives from examples and ensure only non-whitespace characters are matched

--- a/changelogs/fragments/fix_find_dependant_imports.yml
+++ b/changelogs/fragments/fix_find_dependant_imports.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - remove description block from yang before matching imports to prevent false positives from examples and ensure only non-whitespace characters are matched
+  - remove description block and comments from yang before matching imports to prevent false positives from examples and ensure only non-whitespace characters are matched

--- a/plugins/module_utils/fetch.py
+++ b/plugins/module_utils/fetch.py
@@ -128,8 +128,9 @@ class SchemaStore(object):
 
         if found:
             result["fetched"][schema_id] = data_model
-            importre = re.compile(r"import (.+) {")
-            all_found = importre.findall(data_model)
+            importre = re.compile(r"import (\S+) {")
+            all_found = re.sub(r"description\s+\"[^\"]+\";", "", data_model)
+            all_found = importre.findall(all_found)
             all_found = [re.sub("['\"]", "", imp) for imp in all_found]
 
             return all_found

--- a/plugins/module_utils/fetch.py
+++ b/plugins/module_utils/fetch.py
@@ -129,7 +129,7 @@ class SchemaStore(object):
         if found:
             result["fetched"][schema_id] = data_model
             importre = re.compile(r"import (\S+) {")
-            all_found = re.sub(r"description\s+\"[^\"]+\";", "", data_model)
+            all_found = re.sub(r"/\*(.|\n)*?\*/|\/\/.*|description\s+\"[^\"]+\";", "", data_model)
             all_found = importre.findall(all_found)
             all_found = [re.sub("['\"]", "", imp) for imp in all_found]
 


### PR DESCRIPTION
##### SUMMARY
Following on from #64 - match on non-whitespace characters in fetch

This PR also fixes the scenario where an `import x {` can be incorrectly matched in a description block causing a fetch failure, e.g. https://github.com/YangModels/yang/blob/master/vendor/cisco/xe/1671/tailf-common.yang#L1601

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
fetch

##### ADDITIONAL INFORMATION
support imports that have extra whitespace

```
  import ietf-yang-types         {
     prefix yang;
  }
```

ignores imports that are found in description blocks by removing the description block before matching
```
  description
     "...
      it MUST be defined in the same module as the
       tailf:unique-selector.  For example, the following is illegal:
         module y {
           ...
           import x {
             prefix x;
           }
           tailf:unique-selector '/x:server' { // illegal
             ...
           }
         }
       For each instance of the node where the selector is defined, it
       is evaluated, and for each node selected by the selector, a
      ...";
```
strips out all comments before looking for imports
```
module example {
        ...

        import test {prefix test;}
        //import ethernet {prefix eth;}
```

```
/*
Some example comment...

module example {
        ...

        import test {prefix test;}
*/
```