### PR TITLE
add ignore_errors for pyang in get action

### DIFF
--- a/changelogs/fragments/pyang_ignore_errors.yml
+++ b/changelogs/fragments/pyang_ignore_errors.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - added optional attribute for get action to ignore errors produced by pyang

--- a/plugins/action/get.py
+++ b/plugins/action/get.py
@@ -109,6 +109,7 @@ class ActionModule(ActionBase):
 
         yang_files = self._task.args.get("file", [])
         search_path = self._task.args.get("search_path")
+        ignore_errors = self._task.args.get("ignore_errors", False)
 
         if not (
             hasattr(self._connection, "socket_path")
@@ -126,7 +127,7 @@ class ActionModule(ActionBase):
             )
         else:
             new_module_args = self._task.args.copy()
-            for item in ["file", "search_path"]:
+            for item in ["file", "search_path", "ignore_errors"]:
                 new_module_args.pop(item, None)
 
             self._display.vvvv(
@@ -149,7 +150,7 @@ class ActionModule(ActionBase):
 
             # convert XML data to JSON data as per RFC 7951 format
             tl = Translator(
-                yang_files, search_path=search_path, debug=self._debug
+                yang_files, search_path=search_path, ignore_errors=ignore_errors, debug=self._debug
             )
             result["json_data"] = tl.xml_to_json(
                 result["stdout"], tmp_dir_path

--- a/plugins/modules/get.py
+++ b/plugins/modules/get.py
@@ -67,6 +67,12 @@ options:
         the default directory path.
     type: path
     default: "~/.ansible/yang/spec"
+  ignore_errors:
+    description:
+      - This is an optional arguement that will ignore any errors produced by pyang when converting yang
+        to other formats
+    type: bool
+    default: false
 requirements:
 - ncclient (>=v0.5.2)
 - pyang
@@ -121,4 +127,12 @@ EXAMPLES = """
         </interface-configuration></interface-configurations>
     file: "{{ playbook_dir }}/YangModels/yang/tree/master/vendor/cisco/xr/613/*.yang"
     search_path: "{{ playbook_dir }}/YangModels/yang/tree/master/vendor/cisco/xr/613:{{ playbook_dir }}/pyang/modules"
+- name: fetch interface configuration and return it in JSON format ignore any errors from pyang
+  community.yang.get:
+    filter: |
+        <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"><interface-configuration>
+        </interface-configuration></interface-configurations>
+    file: "{{ playbook_dir }}/YangModels/yang/tree/master/vendor/cisco/xr/613/*.yang"
+    search_path: "{{ playbook_dir }}/YangModels/yang/tree/master/vendor/cisco/xr/613:{{ playbook_dir }}/pyang/modules"
+    ignore_errors: true
 """


### PR DESCRIPTION
##### SUMMARY
Add option to ignore errors/warning produced by pyang when converting yang to other formats, e.g. xsl.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.yang.get

##### ADDITIONAL INFORMATION
Any errors produced by the pyang formatting will cause pyang's `jsonxsl.py` module to raise an exception https://github.com/mbj4668/pyang/blob/de7a4be61fa699929a31a404e1b696c57737fa5f/pyang/plugins/jsonxsl.py#L73, including warnings about modules that are implicitly included not being used, etc. Passing `--ignore-errors` to the pyang exec allows the translator to complete successfully.

```
TASK [get interface configuration in json format] **************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: JSONXSL plugin needs a valid module
fatal: [router-1]: FAILED! => {"changed": false, "msg": "Error while generating (xsl) intermediate file: /ansible/files/yang/ietf-inet-types.yang:6: warning: imported module \"tailf-common\" not used\nJSONXSL plugin needs a valid module\n"}

PLAY RECAP *********************************************************************************************************************************
router-1                    : ok=1    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
